### PR TITLE
OPS-3612 Fix custom facts script from rundeck-puppet

### DIFF
--- a/manifests/facts.pp
+++ b/manifests/facts.pp
@@ -25,7 +25,7 @@ class rundeck::facts(
     $ruby_bin = '/opt/puppet/bin/ruby'
     $dir      = 'puppetlabs/'
   } else {
-    $ruby_bin = '/usr/bin/env ruby'
+    $ruby_bin = '/opt/puppetlabs/puppet/bin/ruby'
     $dir      = ''
   }
 


### PR DESCRIPTION
The current facts script is broken, because it fails to find a working ruby
interpreter on the Rundeck machines (there is nono installed). This changes
lets it use the same ruby version used by the puppet agent itself.